### PR TITLE
Add canonical link to stable/index.html in main page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,8 @@
 <!DOCTYPE html>
 <html>
-	<head><meta http-equiv="refresh" content="0; url=./stable" /></head>
+	<head>
+		<meta http-equiv="refresh" content="0; url=./stable" />
+		<link rel="canonical" href="https://torchjd.org/stable/index.html">
+	</head>
 	<body></body>
 </html>


### PR DESCRIPTION
@PierreQuinton I think this is better. The canonical page will now be torchjd.org/stable/index.html, like it should be in my opinion.