### PR TITLE
Add favicon link to home page so logo shows in Google search

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 	<head>
 		<meta http-equiv="refresh" content="0; url=./stable" />
 		<link rel="canonical" href="https://torchjd.org/stable/index.html">
+		<link rel="icon" href="/stable/_static/favicon.ico" sizes="any">
 	</head>
 	<body></body>
 </html>


### PR DESCRIPTION
## Problem

The TorchJD logo stopped appearing next to `torchjd.org` in Google search results around the April 2025 docs-deployment restructure (versioned subfolders `/stable`, `/latest`, …). The site root became a bare meta-refresh redirect with **no favicon**, and `https://torchjd.org/favicon.ico` returns 404 — so Google, which reads a site's favicon from the home page `<head>` (or `/favicon.ico` at the root), can no longer find one.

## Fix

Add a favicon `<link>` to the root `index.html`, pointing at the favicon that is **already deployed** under `/stable/_static/favicon.ico`. No file is duplicated.

```html
<link rel="icon" href="/stable/_static/favicon.ico" sizes="any">
```

## After merge

Request reindexing of `torchjd.org/` in Google Search Console — favicons only refresh on re-crawl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)